### PR TITLE
fix(ci): enable contents:write permission and bump version to 0.2.1

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -8,7 +8,7 @@ on:
 
 permissions:
   id-token: write # Required for OIDC trusted publishing
-  contents: read # Required for creating tags and releases
+  contents: write # Required for creating tags and releases
 
 jobs:
   publish:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@consolidados/results",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Result types, ease and simple",
   "main": "./dist/index.js",
   "module": "./dist/index.js",


### PR DESCRIPTION
Changes:
- Update workflow permissions from contents:read to contents:write to allow pushing tags and creating releases
- Bump package version to 0.2.1 (0.2.0 was successfully published)

Previous error:
  remote: Permission to ConsoliDados/results.git denied to github-actions[bot]

This was caused by insufficient permissions to push tags.

🤖 Generated with [Claude Code](https://claude.com/claude-code)