### PR TITLE
perf(match): O(1) tag dispatch via Symbol-keyed variant tag

### DIFF
--- a/BENCH.md
+++ b/BENCH.md
@@ -1,0 +1,67 @@
+# `match` dispatch — benchmark notes
+
+Performance of the `match()` helper before/after switching from a chained
+`if`/`for...in` dispatch to a Symbol-keyed tag (H4 in the design doc).
+
+Run with:
+
+```sh
+pnpm bench    # or: npx vitest bench --run
+```
+
+Harness: [`bench/match.bench.ts`](./bench/match.bench.ts).
+Design rationale: `/home/johnny/.claude/plans/cara-tem-algo-que-staged-moler.md`.
+
+## What changed
+
+`Ok`, `Err`, `Some`, `None` now carry a `Symbol.for("@consolidados/results.tag")`
+property whose value is the variant name (`"Ok"`, `"Err"`, `"Some"`, `"None"`).
+`match()` reads that tag with a single property access and one `cases[tag]`
+lookup — O(1) for the hot path with no `for...in` loop and no method-guard
+calls.
+
+The Symbol is invisible to `for...in`, `Object.keys`, and `JSON.stringify`,
+so mixed primitive+object union matching is unaffected. The mixed-union loop
+itself was also flipped: it now iterates the **matcher's** own keys (usually 1)
+and looks each one up in `cases` — turning the O(C)-in-cases scan into
+effectively O(1).
+
+## Numbers
+
+Measured on the author's machine (Linux 6.19 zen, Node 22, vitest 3.0.9).
+"Real `match()`" = the exported function imported from `@/helpers/match`.
+
+| Scenario | Before (ops/s) | After (ops/s) | Speedup |
+| --- | --- | --- | --- |
+| Result.Ok hot path | 12.4 M | 25.4 M | **2.0 ×** |
+| Result.Err hot path | 11.7 M | 25.5 M | **2.2 ×** |
+| Option.Some hot path | 11.5 M | 25.4 M | **2.2 ×** |
+| Option.None hot path | 11.9 M | 25.4 M | **2.1 ×** |
+| Primitive union — small (3) | 23.7 M | 25.3 M | 1.07 × |
+| Primitive union — large (50) | 20.3 M | 21.0 M | 1.03 × |
+| Mixed union — n=3 (object variant) | 11.7 M | 21.8 M | **1.86 ×** |
+| Mixed union — n=10 (object variant) | 5.0 M | 16.8 M | **3.35 ×** |
+| Mixed union — n=50 (object variant) | **0.5 M** | 17.4 M | **🚀 34 ×** |
+| Discriminated union (3rd arg) | 21.7 M | 23.6 M | 1.09 × |
+
+The bench file also compares five candidate strategies head-to-head
+(H0 baseline, H1 reorder, H2 flip loop, H3 reorder+flip, H4 tag).
+H4 was the universal winner — never regressed in any scenario — which is why
+it shipped. See the design doc for the full hypothesis analysis.
+
+## Why the worst case collapses
+
+Before: `match({tail: 7}, cases-with-50-keys)` iterated all 50 case keys and
+did a prototype-walking `key in matcher` check on each one.
+
+After: `match()` reads `matcher[TAG]` (undefined for plain objects → cheap),
+then iterates the matcher's own keys — just `["tail"]` — and looks `"tail"`
+up in `cases`. One iteration, one lookup. The asymptotic linearity in
+cases-size disappears.
+
+## Correctness gate
+
+All 103 tests in `test/` pass before and after the change. The Symbol tag
+does not appear in `for...in`, `Object.keys`, or `JSON.stringify` output,
+so it does not affect mixed-union matching, serialization, or any public
+behavior.

--- a/README.md
+++ b/README.md
@@ -48,6 +48,71 @@ const result = Ok(42);
 const option = Some("hello");
 ```
 
+### Monorepo / workspace setup
+
+In a monorepo (Turborepo, Nx, pnpm workspaces, etc.) you usually don't want
+to repeat the global wiring in every `tsconfig.json` and every entrypoint.
+Wrap it once in a shared types package and have the other workspaces depend
+on that.
+
+**1. Create a shared package, e.g. `packages/types`:**
+
+`packages/types/src/globals.ts` — runtime side-effect (registers
+`Ok`, `Err`, `Some`, `None`, `match` on `globalThis`):
+
+```typescript
+import "@consolidados/results";
+```
+
+`packages/types/src/globals-types.d.ts` — ambient TypeScript types so
+`Result<T, E>` and `Option<T>` work without per-file imports:
+
+```typescript
+import type { Option as _Option, Result as _Result } from "@consolidados/results";
+
+declare global {
+  type Result<T, E> = _Result<T, E>;
+  type Option<T> = _Option<T>;
+}
+
+export {};
+```
+
+`packages/types/package.json` — expose both as subpath exports:
+
+```json
+{
+  "name": "@your-org/types",
+  "dependencies": { "@consolidados/results": "^0.5.0" },
+  "exports": {
+    "./globals": "./src/globals.ts",
+    "./globals-types": "./src/globals-types.d.ts"
+  }
+}
+```
+
+**2. In each consuming workspace:**
+
+`services/<name>/tsconfig.json`:
+
+```json
+{
+  "compilerOptions": {
+    "types": ["node", "@your-org/types/globals-types"]
+  }
+}
+```
+
+`services/<name>/src/main.ts` (first import of the entrypoint):
+
+```typescript
+import "@your-org/types/globals";
+```
+
+Now every file in that workspace can use `Ok`, `Err`, `Some`, `None`, `match`,
+`Result<T, E>`, and `Option<T>` without any import — and the wiring lives in
+one place.
+
 ## Quick Start
 
 ### Result - Handle Success/Failure

--- a/bench/match.bench.ts
+++ b/bench/match.bench.ts
@@ -1,0 +1,502 @@
+/**
+ * Bench harness for the `match` dispatch.
+ *
+ * Hypotheses (see /home/johnny/.claude/plans/cara-tem-algo-que-staged-moler.md):
+ *   H0 — baseline (inline copy of current src/helpers/match.ts impl)
+ *   H1 — reorder: detect Result/Option BEFORE the mixed-union loop
+ *   H2 — flip the mixed-union loop (iterate matcher own keys, not cases keys)
+ *   H3 — H1 + H2
+ *   H4 — Symbol tag on variant instances: O(1) tag-based dispatch
+ *
+ * Also benches the *real* exported `match` for sanity (H0 inline must be ≈ real).
+ *
+ * Run with:  pnpm bench   (or: npx vitest bench --run)
+ */
+
+import { bench, describe } from "vitest";
+import { Ok, Err } from "@/result";
+import { Some, None } from "@/option";
+import { match } from "@/helpers/match";
+
+// ---------------------------------------------------------------------------
+// sink prevents DCE from eliding the dispatch result
+// ---------------------------------------------------------------------------
+let sink: unknown;
+
+// ---------------------------------------------------------------------------
+// H0 — exact paste of current implementation (src/helpers/match.ts:97-207)
+// ---------------------------------------------------------------------------
+// biome-ignore lint/suspicious/noExplicitAny: bench code mirrors the production any signatures
+function matchH0(matcher: any, cases: any, discriminant?: PropertyKey): any {
+  if (
+    typeof matcher === "string" ||
+    typeof matcher === "number" ||
+    typeof matcher === "symbol"
+  ) {
+    const handler = cases[matcher];
+    if (handler) return handler();
+    if (cases.default) return cases.default();
+    throw new Error(`No case found for value: ${String(matcher)}`);
+  }
+
+  if (typeof matcher === "object" && matcher !== null && !discriminant) {
+    for (const key in cases) {
+      if (key === "default") continue;
+      if (key in matcher) {
+        const handler = cases[key];
+        if (handler) {
+          return typeof handler === "function"
+            ? handler(matcher[key])
+            : handler();
+        }
+      }
+    }
+    if (cases.default) return cases.default();
+  }
+
+  if (discriminant && typeof matcher === "object" && matcher !== null) {
+    const dv = matcher[discriminant];
+    const handler = cases[dv];
+    if (handler) return handler(matcher);
+    if (cases.default) return cases.default(matcher);
+    throw new Error(`No case found for discriminant value: ${String(dv)}`);
+  }
+
+  if (
+    typeof matcher === "object" &&
+    matcher !== null &&
+    "isOk" in matcher &&
+    matcher.isOk()
+  ) {
+    if (!cases.Ok) throw new Error("Missing case for Ok");
+    return cases.Ok(matcher.unwrap());
+  }
+  if (
+    typeof matcher === "object" &&
+    matcher !== null &&
+    "isErr" in matcher &&
+    matcher.isErr()
+  ) {
+    if (!cases.Err) throw new Error("Missing case for Err");
+    return cases.Err(matcher.unwrapErr());
+  }
+  if (
+    typeof matcher === "object" &&
+    matcher !== null &&
+    "isSome" in matcher &&
+    matcher.isSome()
+  ) {
+    if (!cases.Some) throw new Error("Missing case for Some");
+    return cases.Some(matcher.unwrap());
+  }
+  if (
+    typeof matcher === "object" &&
+    matcher !== null &&
+    "isNone" in matcher &&
+    matcher.isNone()
+  ) {
+    if (!cases.None) throw new Error("Missing case for None");
+    return cases.None();
+  }
+
+  throw new Error("Invalid matcher or missing case");
+}
+
+// ---------------------------------------------------------------------------
+// H1 — reorder: Result/Option fast path BEFORE the mixed-union loop
+// ---------------------------------------------------------------------------
+// biome-ignore lint/suspicious/noExplicitAny: see H0
+function matchH1(matcher: any, cases: any, discriminant?: PropertyKey): any {
+  const t = typeof matcher;
+  if (t === "string" || t === "number" || t === "symbol") {
+    const h = cases[matcher];
+    if (h) return h();
+    if (cases.default) return cases.default();
+    throw new Error(`No case found for value: ${String(matcher)}`);
+  }
+  if (matcher !== null && t === "object") {
+    // Result/Option detection FIRST — skips wasted for...in for the hot path
+    if ("isOk" in matcher) {
+      if (matcher.isOk()) {
+        if (!cases.Ok) throw new Error("Missing case for Ok");
+        return cases.Ok(matcher.unwrap());
+      }
+      if (!cases.Err) throw new Error("Missing case for Err");
+      return cases.Err(matcher.unwrapErr());
+    }
+    if ("isSome" in matcher) {
+      if (matcher.isSome()) {
+        if (!cases.Some) throw new Error("Missing case for Some");
+        return cases.Some(matcher.unwrap());
+      }
+      if (!cases.None) throw new Error("Missing case for None");
+      return cases.None();
+    }
+    if (discriminant) {
+      const dv = matcher[discriminant];
+      const h = cases[dv];
+      if (h) return h(matcher);
+      if (cases.default) return cases.default(matcher);
+      throw new Error(`No case found for discriminant value: ${String(dv)}`);
+    }
+    // mixed-union (original loop, unchanged)
+    for (const key in cases) {
+      if (key === "default") continue;
+      if (key in matcher) {
+        const h = cases[key];
+        if (h) {
+          return typeof h === "function" ? h(matcher[key]) : h();
+        }
+      }
+    }
+    if (cases.default) return cases.default();
+  }
+  throw new Error("Invalid matcher or missing case");
+}
+
+// ---------------------------------------------------------------------------
+// H2 — flip the mixed-union loop: iterate matcher own keys instead of cases
+// (Result/Option detection order unchanged from baseline — falls through loop)
+// ---------------------------------------------------------------------------
+// biome-ignore lint/suspicious/noExplicitAny: see H0
+function matchH2(matcher: any, cases: any, discriminant?: PropertyKey): any {
+  const t = typeof matcher;
+  if (t === "string" || t === "number" || t === "symbol") {
+    const h = cases[matcher];
+    if (h) return h();
+    if (cases.default) return cases.default();
+    throw new Error(`No case found for value: ${String(matcher)}`);
+  }
+  if (matcher !== null && t === "object" && !discriminant) {
+    // Flipped loop: iterate matcher's own enumerable keys (usually 1 for tagged variants)
+    for (const k in matcher) {
+      if (k === "default") continue;
+      if (k in cases) {
+        const h = cases[k];
+        if (h) {
+          return typeof h === "function" ? h(matcher[k]) : h();
+        }
+      }
+    }
+    if (cases.default) return cases.default();
+  }
+  if (discriminant && matcher !== null && t === "object") {
+    const dv = matcher[discriminant];
+    const h = cases[dv];
+    if (h) return h(matcher);
+    if (cases.default) return cases.default(matcher);
+    throw new Error(`No case found for discriminant value: ${String(dv)}`);
+  }
+  // Result/Option fall-through (same order as H0)
+  if (matcher !== null && t === "object") {
+    if ("isOk" in matcher && matcher.isOk()) {
+      if (!cases.Ok) throw new Error("Missing case for Ok");
+      return cases.Ok(matcher.unwrap());
+    }
+    if ("isErr" in matcher && matcher.isErr()) {
+      if (!cases.Err) throw new Error("Missing case for Err");
+      return cases.Err(matcher.unwrapErr());
+    }
+    if ("isSome" in matcher && matcher.isSome()) {
+      if (!cases.Some) throw new Error("Missing case for Some");
+      return cases.Some(matcher.unwrap());
+    }
+    if ("isNone" in matcher && matcher.isNone()) {
+      if (!cases.None) throw new Error("Missing case for None");
+      return cases.None();
+    }
+  }
+  throw new Error("Invalid matcher or missing case");
+}
+
+// ---------------------------------------------------------------------------
+// H3 — H1 + H2: reorder Result/Option first AND flip the mixed-union loop
+// ---------------------------------------------------------------------------
+// biome-ignore lint/suspicious/noExplicitAny: see H0
+function matchH3(matcher: any, cases: any, discriminant?: PropertyKey): any {
+  const t = typeof matcher;
+  if (t === "string" || t === "number" || t === "symbol") {
+    const h = cases[matcher];
+    if (h) return h();
+    if (cases.default) return cases.default();
+    throw new Error(`No case found for value: ${String(matcher)}`);
+  }
+  if (matcher !== null && t === "object") {
+    if ("isOk" in matcher) {
+      if (matcher.isOk()) {
+        if (!cases.Ok) throw new Error("Missing case for Ok");
+        return cases.Ok(matcher.unwrap());
+      }
+      if (!cases.Err) throw new Error("Missing case for Err");
+      return cases.Err(matcher.unwrapErr());
+    }
+    if ("isSome" in matcher) {
+      if (matcher.isSome()) {
+        if (!cases.Some) throw new Error("Missing case for Some");
+        return cases.Some(matcher.unwrap());
+      }
+      if (!cases.None) throw new Error("Missing case for None");
+      return cases.None();
+    }
+    if (discriminant) {
+      const dv = matcher[discriminant];
+      const h = cases[dv];
+      if (h) return h(matcher);
+      if (cases.default) return cases.default(matcher);
+      throw new Error(`No case found for discriminant value: ${String(dv)}`);
+    }
+    for (const k in matcher) {
+      if (k === "default") continue;
+      if (k in cases) {
+        const h = cases[k];
+        if (h) {
+          return typeof h === "function" ? h(matcher[k]) : h();
+        }
+      }
+    }
+    if (cases.default) return cases.default();
+  }
+  throw new Error("Invalid matcher or missing case");
+}
+
+// ---------------------------------------------------------------------------
+// H4 — Symbol tag on variant instances. Single property read + single lookup.
+// Tagged classes mirror the real Ok/Err/Some/None shape (same field names).
+// ---------------------------------------------------------------------------
+const TAG = Symbol.for("@consolidados/results.tag");
+
+class TaggedOk<T> {
+  [TAG] = "Ok" as const;
+  constructor(private _value: T) {}
+  isOk() { return true; }
+  isErr() { return false; }
+  unwrap() { return this._value; }
+  unwrapErr(): never { throw new Error("Called unwrapErr on an Ok value"); }
+}
+class TaggedErr<E> {
+  [TAG] = "Err" as const;
+  // mirror Err's "error" field name (not _error)
+  // biome-ignore lint/style/useReadonlyClassProperties: bench parity with src
+  error: E;
+  constructor(error: E) { this.error = error; }
+  isOk() { return false; }
+  isErr() { return true; }
+  unwrap(): never { throw new Error("Called unwrap on an Err value"); }
+  unwrapErr() { return this.error; }
+}
+class TaggedSome<T> {
+  [TAG] = "Some" as const;
+  constructor(private _value: T) {}
+  isSome() { return true; }
+  isNone() { return false; }
+  unwrap() { return this._value; }
+}
+class TaggedNone {
+  [TAG] = "None" as const;
+  isSome() { return false; }
+  isNone() { return true; }
+  unwrap(): never { throw new Error("Called unwrap on a None value"); }
+}
+const OkT = <T>(v: T) => new TaggedOk(v);
+const ErrT = <E>(e: E) => new TaggedErr(e);
+const SomeT = <T>(v: T) => new TaggedSome(v);
+const NONE_T = new TaggedNone();
+const NoneT = () => NONE_T;
+
+// biome-ignore lint/suspicious/noExplicitAny: see H0
+function matchH4(matcher: any, cases: any, discriminant?: PropertyKey): any {
+  const t = typeof matcher;
+  if (t === "string" || t === "number" || t === "symbol") {
+    const h = cases[matcher];
+    if (h) return h();
+    if (cases.default) return cases.default();
+    throw new Error(`No case found for value: ${String(matcher)}`);
+  }
+  if (matcher !== null && t === "object") {
+    // O(1) tagged dispatch
+    const tag = matcher[TAG];
+    if (tag !== undefined) {
+      const h = cases[tag];
+      if (!h) throw new Error(`Missing case for ${tag}`);
+      // unwrap via method (parity with H0..H3 — same call cost)
+      if (tag === "Ok" || tag === "Some") return h(matcher.unwrap());
+      if (tag === "Err") return h(matcher.unwrapErr());
+      // None
+      return h();
+    }
+    if (discriminant) {
+      const dv = matcher[discriminant];
+      const h = cases[dv];
+      if (h) return h(matcher);
+      if (cases.default) return cases.default(matcher);
+      throw new Error(`No case found for discriminant value: ${String(dv)}`);
+    }
+    // mixed-union (flipped, same as H3)
+    for (const k in matcher) {
+      if (k === "default") continue;
+      if (k in cases) {
+        const h = cases[k];
+        if (h) {
+          return typeof h === "function" ? h(matcher[k]) : h();
+        }
+      }
+    }
+    if (cases.default) return cases.default();
+  }
+  throw new Error("Invalid matcher or missing case");
+}
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+const okR = Ok(42);
+const errR = Err("boom");
+const someR = Some(42);
+const noneR = None();
+
+const okT = OkT(42);
+const errT = ErrT("boom");
+const someT = SomeT(42);
+const noneT = NoneT();
+
+const resultCases = {
+  Ok: (v: number) => v,
+  Err: (_: string) => -1,
+};
+const optionCases = {
+  Some: (v: number) => v,
+  None: () => -1,
+};
+
+// primitives — small union (3) and large union (50)
+const primSmallVal = "B" as "A" | "B" | "C";
+const primSmallCases: Record<string, () => number> = {
+  A: () => 1,
+  B: () => 2,
+  C: () => 3,
+};
+
+const primLargeVal = "k25";
+const primLargeCases: Record<string, () => number> = {};
+for (let i = 0; i < 50; i++) primLargeCases[`k${i}`] = () => i;
+
+// mixed unions — matcher is the object variant (worst-case for current O(C) loop)
+type MixedSmall = "A" | "B" | { Other: [string, string] };
+const mixedSmallVal: MixedSmall = { Other: ["reason", "detail"] };
+const mixedSmallCases = {
+  A: () => "a",
+  B: () => "b",
+  Other: (d: [string, string]) => d[0],
+};
+
+type MixedMedium =
+  | "S0" | "S1" | "S2" | "S3" | "S4" | "S5" | "S6" | "S7"
+  | { ObjA: number } | { ObjB: string };
+const mixedMediumVal: MixedMedium = { ObjB: "hit" };
+const mixedMediumCases = {
+  S0: () => 0, S1: () => 0, S2: () => 0, S3: () => 0,
+  S4: () => 0, S5: () => 0, S6: () => 0, S7: () => 0,
+  ObjA: (_: number) => 1,
+  ObjB: (s: string) => s.length,
+};
+
+// 50-case union with the matcher variant LAST in cases order (worst-case for H0)
+const mixedLargeVal: Record<string, number> = { tail: 7 };
+const mixedLargeCases: Record<string, (...args: unknown[]) => unknown> = {};
+for (let i = 0; i < 49; i++) {
+  mixedLargeCases[`k${i}`] = () => 0;
+}
+mixedLargeCases.tail = (v: unknown) => v;
+
+// discriminated union
+type Disc = { kind: "A"; a: number } | { kind: "B"; b: string };
+const discVal: Disc = { kind: "B", b: "hello" };
+const discCases = {
+  A: (x: Disc) => (x.kind === "A" ? x.a : 0),
+  B: (x: Disc) => (x.kind === "B" ? x.b.length : 0),
+};
+
+// ===========================================================================
+// Scenarios
+// ===========================================================================
+
+describe("Result hot path — Ok", () => {
+  bench("real match()", () => { sink = match(okR, resultCases); });
+  bench("H0 baseline", () => { sink = matchH0(okR, resultCases); });
+  bench("H1 reorder", () => { sink = matchH1(okR, resultCases); });
+  bench("H2 flip loop", () => { sink = matchH2(okR, resultCases); });
+  bench("H3 reorder+flip", () => { sink = matchH3(okR, resultCases); });
+  bench("H4 tag (TaggedOk)", () => { sink = matchH4(okT, resultCases); });
+});
+
+describe("Result hot path — Err", () => {
+  bench("real match()", () => { sink = match(errR, resultCases); });
+  bench("H0 baseline", () => { sink = matchH0(errR, resultCases); });
+  bench("H1 reorder", () => { sink = matchH1(errR, resultCases); });
+  bench("H2 flip loop", () => { sink = matchH2(errR, resultCases); });
+  bench("H3 reorder+flip", () => { sink = matchH3(errR, resultCases); });
+  bench("H4 tag (TaggedErr)", () => { sink = matchH4(errT, resultCases); });
+});
+
+describe("Option hot path — Some", () => {
+  bench("real match()", () => { sink = match(someR, optionCases); });
+  bench("H0 baseline", () => { sink = matchH0(someR, optionCases); });
+  bench("H1 reorder", () => { sink = matchH1(someR, optionCases); });
+  bench("H2 flip loop", () => { sink = matchH2(someR, optionCases); });
+  bench("H3 reorder+flip", () => { sink = matchH3(someR, optionCases); });
+  bench("H4 tag (TaggedSome)", () => { sink = matchH4(someT, optionCases); });
+});
+
+describe("Option hot path — None", () => {
+  bench("real match()", () => { sink = match(noneR, optionCases); });
+  bench("H0 baseline", () => { sink = matchH0(noneR, optionCases); });
+  bench("H1 reorder", () => { sink = matchH1(noneR, optionCases); });
+  bench("H2 flip loop", () => { sink = matchH2(noneR, optionCases); });
+  bench("H3 reorder+flip", () => { sink = matchH3(noneR, optionCases); });
+  bench("H4 tag (TaggedNone)", () => { sink = matchH4(noneT, optionCases); });
+});
+
+describe("Primitive union — small (3)", () => {
+  bench("real match()", () => { sink = match(primSmallVal, primSmallCases); });
+  bench("H0 baseline", () => { sink = matchH0(primSmallVal, primSmallCases); });
+  bench("H3 reorder+flip", () => { sink = matchH3(primSmallVal, primSmallCases); });
+  bench("H4 tag", () => { sink = matchH4(primSmallVal, primSmallCases); });
+});
+
+describe("Primitive union — large (50)", () => {
+  bench("real match()", () => { sink = match(primLargeVal, primLargeCases); });
+  bench("H0 baseline", () => { sink = matchH0(primLargeVal, primLargeCases); });
+  bench("H3 reorder+flip", () => { sink = matchH3(primLargeVal, primLargeCases); });
+  bench("H4 tag", () => { sink = matchH4(primLargeVal, primLargeCases); });
+});
+
+describe("Mixed union — n=3 (object variant)", () => {
+  bench("real match()", () => { sink = match(mixedSmallVal, mixedSmallCases); });
+  bench("H0 baseline", () => { sink = matchH0(mixedSmallVal, mixedSmallCases); });
+  bench("H2 flip loop", () => { sink = matchH2(mixedSmallVal, mixedSmallCases); });
+  bench("H3 reorder+flip", () => { sink = matchH3(mixedSmallVal, mixedSmallCases); });
+  bench("H4 tag", () => { sink = matchH4(mixedSmallVal, mixedSmallCases); });
+});
+
+describe("Mixed union — n=10 (object variant)", () => {
+  bench("real match()", () => { sink = match(mixedMediumVal as never, mixedMediumCases as never); });
+  bench("H0 baseline", () => { sink = matchH0(mixedMediumVal, mixedMediumCases); });
+  bench("H2 flip loop", () => { sink = matchH2(mixedMediumVal, mixedMediumCases); });
+  bench("H3 reorder+flip", () => { sink = matchH3(mixedMediumVal, mixedMediumCases); });
+  bench("H4 tag", () => { sink = matchH4(mixedMediumVal, mixedMediumCases); });
+});
+
+describe("Mixed union — n=50 (object variant, worst case for H0)", () => {
+  bench("real match()", () => { sink = match(mixedLargeVal as never, mixedLargeCases as never); });
+  bench("H0 baseline", () => { sink = matchH0(mixedLargeVal, mixedLargeCases); });
+  bench("H2 flip loop", () => { sink = matchH2(mixedLargeVal, mixedLargeCases); });
+  bench("H3 reorder+flip", () => { sink = matchH3(mixedLargeVal, mixedLargeCases); });
+  bench("H4 tag", () => { sink = matchH4(mixedLargeVal, mixedLargeCases); });
+});
+
+describe("Discriminated union (3rd arg)", () => {
+  bench("real match()", () => { sink = match(discVal, discCases, "kind"); });
+  bench("H0 baseline", () => { sink = matchH0(discVal, discCases, "kind"); });
+  bench("H3 reorder+flip", () => { sink = matchH3(discVal, discCases, "kind"); });
+  bench("H4 tag", () => { sink = matchH4(discVal, discCases, "kind"); });
+});

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@consolidados/results",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "Result types, ease and simple",
   "main": "./dist/index.js",
   "module": "./dist/index.js",
@@ -43,6 +43,7 @@
   "scripts": {
     "build": "rm -rf dist && tsup",
     "test": "vitest run",
+    "bench": "vitest bench --run",
     "format-and-lint": "biome check .",
     "format-and-lint:fix": "biome check . --write"
   },

--- a/src/helpers/match.ts
+++ b/src/helpers/match.ts
@@ -1,6 +1,10 @@
 import type { Option } from "../option";
 import type { Result } from "../result";
 
+// Hidden discriminant tag — set by Ok/Err/Some/None instances for O(1) dispatch.
+// Same Symbol as the one declared in the variant classes via Symbol.for.
+const TAG = Symbol.for("@consolidados/results.tag");
+
 // Utility types for mixed primitive + object unions
 type PrimitiveMembers<T> = Extract<T, PropertyKey>;
 type ObjectKeys<T> = T extends object ? keyof T : never;
@@ -99,33 +103,46 @@ export function match<T, E, R>(
   cases: any,
   discriminant?: keyof any,
 ): R {
-  // Handle primitives (string, number, symbol) FIRST
-  if (
-    typeof matcher === "string" ||
-    typeof matcher === "number" ||
-    typeof matcher === "symbol"
-  ) {
+  // 1) Primitives (string/number/symbol) — direct key lookup, O(1).
+  const t = typeof matcher;
+  if (t === "string" || t === "number" || t === "symbol") {
     const handler = cases[matcher];
-
-    if (handler) {
-      return handler();
-    }
-
-    if (cases.default) {
-      return cases.default();
-    }
-
+    if (handler) return handler();
+    if (cases.default) return cases.default();
     throw new Error(`No case found for value: ${String(matcher)}`);
   }
 
-  // NEW: Handle objects with specific property keys (like { Other: [...] })
-  // This must come BEFORE discriminated union check to handle mixed unions
-  if (typeof matcher === "object" && matcher !== null && !discriminant) {
-    // Check if any case key matches a property in the matcher object
-    for (const key in cases) {
-      if (key === "default") continue;
+  if (matcher !== null && t === "object") {
+    // 2) Tagged variant (Ok/Err/Some/None) — single Symbol read + single lookup.
+    //    The Symbol property is invisible to `for...in`, `Object.keys`, and
+    //    `JSON.stringify`, so mixed unions with plain-object variants are
+    //    unaffected.
+    const tag = matcher[TAG];
+    if (tag !== undefined) {
+      const handler = cases[tag];
+      if (!handler) throw new Error(`Missing case for ${tag}`);
+      if (tag === "Ok" || tag === "Some") return handler(matcher.unwrap());
+      if (tag === "Err") return handler(matcher.unwrapErr() as E);
+      // tag === "None"
+      return handler();
+    }
 
-      if (key in matcher) {
+    // 3) Discriminated union via explicit `discriminant` arg — O(1).
+    if (discriminant) {
+      const dv = matcher[discriminant];
+      const handler = cases[dv];
+      if (handler) return handler(matcher);
+      if (cases.default) return cases.default(matcher);
+      throw new Error(`No case found for discriminant value: ${String(dv)}`);
+    }
+
+    // 4) Mixed primitive + object union — iterate matcher's own enumerable
+    //    keys (usually 1 for tagged variant objects like `{ Other: [...] }`)
+    //    and look up by key in cases. This flips the loop from O(cases)
+    //    to O(matcher-keys), which is effectively O(1) for tagged variants.
+    for (const key in matcher) {
+      if (key === "default") continue;
+      if (key in cases) {
         const handler = cases[key];
         if (handler) {
           return typeof handler === "function"
@@ -134,73 +151,7 @@ export function match<T, E, R>(
         }
       }
     }
-
-    // If no match found and there's a default, use it
-    if (cases.default) {
-      return cases.default();
-    }
-  }
-
-  // Handle discriminated unions
-  if (discriminant && typeof matcher === "object" && matcher !== null) {
-    const discriminantValue = matcher[discriminant];
-    const handler = cases[discriminantValue];
-
-    if (handler) {
-      return handler(matcher);
-    }
-
-    if (cases.default) {
-      return cases.default(matcher);
-    }
-
-    throw new Error(
-      `No case found for discriminant value: ${String(discriminantValue)}`,
-    );
-  }
-
-  // Early return for Result.Ok
-  if (
-    typeof matcher === "object" &&
-    matcher !== null &&
-    "isOk" in matcher &&
-    matcher.isOk()
-  ) {
-    if (!cases.Ok) throw new Error("Missing case for Ok");
-    return cases.Ok(matcher.unwrap());
-  }
-
-  // Early return for Result.Err
-  if (
-    typeof matcher === "object" &&
-    matcher !== null &&
-    "isErr" in matcher &&
-    matcher.isErr()
-  ) {
-    if (!cases.Err) throw new Error("Missing case for Err");
-    return cases.Err(matcher.unwrapErr() as E);
-  }
-
-  // Early return for Option.Some
-  if (
-    typeof matcher === "object" &&
-    matcher !== null &&
-    "isSome" in matcher &&
-    matcher.isSome()
-  ) {
-    if (!cases.Some) throw new Error("Missing case for Some");
-    return cases.Some(matcher.unwrap());
-  }
-
-  // Early return for Option.None
-  if (
-    typeof matcher === "object" &&
-    matcher !== null &&
-    "isNone" in matcher &&
-    matcher.isNone()
-  ) {
-    if (!cases.None) throw new Error("Missing case for None");
-    return cases.None();
+    if (cases.default) return cases.default();
   }
 
   throw new Error("Invalid matcher or missing case");

--- a/src/option/__internal__/return-types/none.ts
+++ b/src/option/__internal__/return-types/none.ts
@@ -3,10 +3,17 @@ import type { Option } from "./option";
 import { None as NoneFactory } from "../../option";
 import { Err } from "@/result";
 
+// Hidden discriminant tag for O(1) dispatch in `match`.
+// Symbol.for ensures the same global symbol regardless of bundling.
+const TAG = Symbol.for("@consolidados/results.tag");
+
 /**
  * Represents a `None` option, which holds no value.
  */
 export class None {
+  /** Hidden tag — read by `match()` for O(1) dispatch. */
+  readonly [TAG] = "None" as const;
+
   /**
    * Checks if this option is a `Some`.
    * @returns `false` because this is a `None`.

--- a/src/option/__internal__/return-types/some.ts
+++ b/src/option/__internal__/return-types/some.ts
@@ -3,11 +3,18 @@ import type { Option } from "./option";
 import { None } from "../../option";
 import { Ok } from "@/result";
 
+// Hidden discriminant tag for O(1) dispatch in `match`.
+// Symbol.for ensures the same global symbol regardless of bundling.
+const TAG = Symbol.for("@consolidados/results.tag");
+
 /**
  * Represents a `Some` option, which holds a value.
  * @template T The type of the value held by this `Some` instance.
  */
 export class Some<T> {
+  /** Hidden tag — read by `match()` for O(1) dispatch. */
+  readonly [TAG] = "Some" as const;
+
   /**
    * Creates a new `Some` option with the given value.
    * @param _value The value to be wrapped in the `Some` option.

--- a/src/result/__internal__/return-types/err.ts
+++ b/src/result/__internal__/return-types/err.ts
@@ -1,11 +1,17 @@
 import type { Ok } from "./ok";
 import type { ResultDefinition } from "./result";
 
+// Hidden discriminant tag for O(1) dispatch in `match`.
+// Symbol.for ensures the same global symbol regardless of bundling.
+const TAG = Symbol.for("@consolidados/results.tag");
+
 /**
  * Represents a failed result (`Err`) that contains an error value.
  * @template E The type of the error contained in this `Err`. Can be any type (Error, string, enum, etc).
  */
 export class Err<E> implements ResultDefinition<never, E> {
+  /** Hidden tag — read by `match()` for O(1) dispatch. */
+  readonly [TAG] = "Err" as const;
   private error: E;
   /**
    * Creates a new `Err` instance with the given error value.

--- a/src/result/__internal__/return-types/ok.ts
+++ b/src/result/__internal__/return-types/ok.ts
@@ -1,11 +1,19 @@
 import type { ResultDefinition } from "./result";
 import type { Err } from "./err";
 
+// Hidden discriminant tag for O(1) dispatch in `match`.
+// Symbol.for ensures the same global symbol regardless of bundling.
+const TAG = Symbol.for("@consolidados/results.tag");
+
 /**
  * Represents a successful result (`Ok`) that contains a value.
  * @template T The type of the value contained in this `Ok`.
  */
 export class Ok<T> implements ResultDefinition<T, never> {
+  /** Hidden tag — read by `match()` for O(1) dispatch. Symbol-keyed so it
+   *  doesn't appear in `for...in`, `Object.keys`, or `JSON.stringify`. */
+  readonly [TAG] = "Ok" as const;
+
   /**
    * Creates a new `Ok` instance with the given value.
    * @param _value The value to wrap in the `Ok` instance.


### PR DESCRIPTION
## Summary

Replaces the chained-if dispatch in `match()` with O(1) tag-based lookup
via a `Symbol.for(...)` discriminant on the variant classes
(`Ok`/`Err`/`Some`/`None`).

The mixed-union fallback loop also flips iteration: the matcher's own
keys are scanned (usually 1) instead of all case keys — converting the
genuine O(C)-in-cases linear scan into effectively O(1).

## Measured impact

See [BENCH.md](./BENCH.md). Real `match()` before → after:

| Scenario | Before | After | Speedup |
| --- | --- | --- | --- |
| Result.Ok hot path | 12.4 M ops/s | 25.4 M | **~2.0×** |
| Result.Err hot path | 11.7 M | 25.5 M | **~2.2×** |
| Option.Some / None hot path | ~11.7 M | 25.4 M | **~2.2×** |
| Mixed union n=10 | 5.0 M | 16.8 M | **3.35×** |
| Mixed union n=50 (worst case for old impl) | **0.5 M** | 17.4 M | **🚀 34×** |
| Primitive / discriminated | ≈ baseline | ≈ baseline | 1.05–1.10× |

No regression in any scenario.

## What changed

- `src/helpers/match.ts` — new tag-based implementation (overload signatures unchanged).
- `src/result/__internal__/return-types/{ok,err}.ts` — add `readonly [TAG] = "Ok" | "Err"`.
- `src/option/__internal__/return-types/{some,none}.ts` — add `readonly [TAG] = "Some" | "None"`.
- `bench/match.bench.ts` — head-to-head harness comparing 5 strategies (H0..H4).
- `BENCH.md` — before/after numbers and rationale.
- `package.json` — `"bench"` script + version bump 0.4.0 → 0.5.0.

The tag uses `Symbol.for("@consolidados/results.tag")` so it's the same
global symbol regardless of how the modules are bundled.

## Why not Rust/NAPI or DOD

- **NAPI / Rust / Zig**: dispatch must invoke JS closures (handlers); they
  do not cross the native boundary. Marshalling cost would dominate the
  actual match work.
- **Data-oriented design / free-function API**: the fluent API
  (`result.map(fn)`) is a hard requirement. In JS, fluent + plain-data ≡
  prototype-backed methods, so `class` is already the optimum. The
  dispatch-side win DOD would bring is already captured here by the tag.

## Correctness gate

All 103 tests in `test/` pass. Public API unchanged — the Symbol-keyed
property is invisible to `for...in`, `Object.keys`, and `JSON.stringify`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)