### PR TITLE
fix(ci): allowlist esbuild for pnpm build scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,5 +69,8 @@
   "publishConfig": {
     "access": "public",
     "provenance": true
+  },
+  "pnpm": {
+    "onlyBuiltDependencies": ["esbuild"]
   }
 }


### PR DESCRIPTION
## Why

The v0.5.0 release workflow failed on `pnpm install --frozen-lockfile`:

\`\`\`
[ERR_PNPM_IGNORED_BUILDS] Ignored build scripts: esbuild@0.25.1
Run "pnpm approve-builds" to pick which dependencies should be allowed to run scripts.
Error: Process completed with exit code 1.
\`\`\`

pnpm v10+ blocks lifecycle scripts of unlisted dependencies by default and
exits non-zero in CI when any are ignored. `esbuild` (transitive via
`vitest` + `tsup`) needs its install script to fetch the correct platform
binary.

## Fix

Add `pnpm.onlyBuiltDependencies` to `package.json`:

\`\`\`json
"pnpm": {
  "onlyBuiltDependencies": ["esbuild"]
}
\`\`\`

Verified locally: `pnpm install --frozen-lockfile` now exits 0 with no
ignored-builds error.

## Release impact

The failed v0.5.0 attempt errored before the publish/tag steps, so
**nothing was published to npm and no v0.5.0 tag exists yet**. After this
fix is in develop, re-merging develop → main will trigger a clean release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)