### PR TITLE
release: v0.5.0 — O(1) match dispatch (retry with CI fix)

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,5 +69,8 @@
   "publishConfig": {
     "access": "public",
     "provenance": true
+  },
+  "pnpm": {
+    "onlyBuiltDependencies": ["esbuild"]
   }
 }


### PR DESCRIPTION
## Release v0.5.0 — retry

Previous attempt (#65) merged successfully but the publish workflow failed
on `pnpm install --frozen-lockfile` due to pnpm v10+ blocking ignored
build scripts. **Nothing was published to npm and no `v0.5.0` tag was
created**, so this is a clean second attempt.

### Includes

- #64 **perf(match): O(1) tag dispatch via Symbol-keyed variant tag**
  - Result/Option hot path: ~2.0–2.2× faster
  - Mixed union n=50 worst case: ~34× faster
  - No regression anywhere; 103/103 tests pass
  - Public API unchanged
- #64 **docs(readme): monorepo / workspace setup** for global usage
- #66 **fix(ci): allowlist esbuild for pnpm build scripts** — the missing
  piece that broke the previous release attempt

### CI on merge

`release.yaml` triggers on push to `main` and will:
1. `pnpm install --frozen-lockfile` ✅ (fixed)
2. `pnpm run test`
3. `pnpm run build`
4. `npm publish --provenance --access public` (OIDC trusted publishing)
5. Create git tag `v0.5.0` and a GitHub Release

🤖 Generated with [Claude Code](https://claude.com/claude-code)