### PR TITLE
fix(ci): use pnpm v11 allowBuilds schema for esbuild postinstall

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,8 +69,5 @@
   "publishConfig": {
     "access": "public",
     "provenance": true
-  },
-  "pnpm": {
-    "onlyBuiltDependencies": ["esbuild"]
   }
 }

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,14 @@
+# pnpm config (this repo is single-package; the file exists only for settings).
+#
+# pnpm v11 changed the build-approval schema:
+#   - v10 reads `onlyBuiltDependencies` (list).
+#   - v11 reads `allowBuilds` (map of pkg → boolean) — the v10 list is silently
+#     ignored on v11 even though it parses without error.
+# We keep both so CI works regardless of which pnpm version the runner uses.
+
+allowBuilds:
+  esbuild: true
+
 onlyBuiltDependencies:
   - core-js
   - esbuild


### PR DESCRIPTION
## Why the previous fix didn't work

#66 added `pnpm.onlyBuiltDependencies` to `package.json`. pnpm v11
**dropped that field entirely** (the CI log showed the warning), so the
setting was silently ignored.

But there's a second, less-obvious problem: the existing
`pnpm-workspace.yaml` already had:

\`\`\`yaml
onlyBuiltDependencies:
  - core-js
  - esbuild
\`\`\`

…and pnpm v11 **also silently ignores `onlyBuiltDependencies`** in
favor of a new `allowBuilds` map. The file parses fine, but the v10
list doesn't grant build approval on v11.

## Fix

Reproduced locally with pnpm 11.4.0 (via `corepack prepare pnpm@latest`):

- Before: `ERR_PNPM_IGNORED_BUILDS: esbuild@0.25.1`, exit 1.
- After: esbuild postinstall runs, install exits 0.

`pnpm-workspace.yaml`:

\`\`\`yaml
allowBuilds:
  esbuild: true

onlyBuiltDependencies:
  - core-js
  - esbuild
\`\`\`

Keep `onlyBuiltDependencies` for compatibility with v10 dev
environments. Also drop the now-dead `pnpm.onlyBuiltDependencies`
field from `package.json` (added in #66, ignored by v11 with a
warning).

## Release impact

Same story as #66: nothing was published, no `v0.5.0` tag was created
(install failed before the publish step). After merging, dev → main
re-merge will trigger a clean v0.5.0 publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)