### PR TITLE
release: v0.5.0 — O(1) match dispatch (retry 2, CI fix)

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,8 +69,5 @@
   "publishConfig": {
     "access": "public",
     "provenance": true
-  },
-  "pnpm": {
-    "onlyBuiltDependencies": ["esbuild"]
   }
 }

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,14 @@
+# pnpm config (this repo is single-package; the file exists only for settings).
+#
+# pnpm v11 changed the build-approval schema:
+#   - v10 reads `onlyBuiltDependencies` (list).
+#   - v11 reads `allowBuilds` (map of pkg → boolean) — the v10 list is silently
+#     ignored on v11 even though it parses without error.
+# We keep both so CI works regardless of which pnpm version the runner uses.
+
+allowBuilds:
+  esbuild: true
+
 onlyBuiltDependencies:
   - core-js
   - esbuild


### PR DESCRIPTION
## Release v0.5.0 — second retry

Previous attempts failed in the install step. **Nothing was ever
published to npm and no `v0.5.0` tag was created**, so this is still a
clean release.

### Includes

- #64 **perf(match): O(1) tag dispatch via Symbol-keyed variant tag**
  - Result/Option hot path: ~2.0–2.2× faster
  - Mixed union n=50 worst case: ~34× faster
  - No regression anywhere; 103/103 tests pass
  - Public API unchanged
- #64 **docs(readme): monorepo / workspace setup** for global usage
- #66 **fix(ci): allowlist esbuild for pnpm build scripts** (v10 schema —
  ignored by v11 with a warning, so wasn't enough by itself)
- #68 **fix(ci): use pnpm v11 `allowBuilds` schema for esbuild postinstall** —
  the real fix; reproduced locally with `pnpm@11.4.0` (exit 0 confirmed)

### CI on merge

`release.yaml` triggers on push to `main`:
1. `pnpm install --frozen-lockfile` ✅ (verified locally with pnpm 11.4.0)
2. `pnpm run test`
3. `pnpm run build`
4. `npm publish --provenance --access public`
5. Create git tag `v0.5.0` and a GitHub Release

🤖 Generated with [Claude Code](https://claude.com/claude-code)