### PR TITLE
chore: pin pnpm to 11.4.0 via packageManager field

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@consolidados/results",
   "version": "0.5.0",
+  "packageManager": "pnpm@11.4.0",
   "description": "Result types, ease and simple",
   "main": "./dist/index.js",
   "module": "./dist/index.js",


### PR DESCRIPTION
## Why

Avoid the v10/v11 schema drift that broke the v0.5.0 release. The v10
list \`onlyBuiltDependencies\` is silently ignored on v11; the v11 map
\`allowBuilds\` is silently absent on v10. Anyone with \`corepack enable\`
will now use exactly **pnpm 11.4.0** — the same version that produced
the current lockfile.

## What

Add to \`package.json\`:

\`\`\`json
"packageManager": "pnpm@11.4.0"
\`\`\`

## Not changed (yet)

\`.github/workflows/release.yaml\` still has
\`pnpm/action-setup@v2 version: latest\`. Currently that resolves to
11.4.0 too. A future PR can drop the \`version\` input and let the
action read from \`packageManager\` for fully deterministic CI — but
that change only takes effect when it lands on \`main\`, so we'll batch
it with the next release.

## How to update pnpm under Corepack

\`\`\`bash
corepack install -g pnpm@latest
# or a specific version:
corepack install -g pnpm@11.5.0
\`\`\`

\`pnpm self-update\` is intentionally disabled by Corepack — the version
is managed at the project level via this \`packageManager\` field.

🤖 Generated with [Claude Code](https://claude.com/claude-code)